### PR TITLE
Change the display of focused buttons

### DIFF
--- a/src/buttons.less
+++ b/src/buttons.less
@@ -27,6 +27,12 @@ button, .paper-btn, input[type="button"] {
     &:hover{
         .shadow-hover;
     }
+    &:focus{
+        border: 2px solid @secondary;
+        -webkit-box-shadow:2px 8px 4px -6px hsla(0,0%,0%,.3);
+        -moz-box-shadow:2px 8px 4px -6px hsla(0,0%,0%,.3);
+        box-shadow:2px 8px 4px -6px hsla(0,0%,0%,.3);
+    }
     &.disabled, &[disabled]{
         .disabled;
     }


### PR DESCRIPTION
## Brief description

This will visually update the display of focused buttons so that users
using a keyboard will differenciate them from other buttons.

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

![screenshot from 2017-11-24 08-35-04](https://user-images.githubusercontent.com/9080102/33200186-c75a5a80-d0f3-11e7-98e3-b3c590507430.png)


## Further details

You'll notice that I manually copied styles of `.shadow-hover`. I tried
```
&:focus{
    border: 2px solid @secondary;
    .shadow-hover;
}
```
without success.